### PR TITLE
validation

### DIFF
--- a/models/match.py
+++ b/models/match.py
@@ -41,5 +41,9 @@ class Match(Base):
         # ["spectrum.id", "spectrum.spectra_data_id", "spectrum.upload_id"],
         # ),
         Index("ix_match_id", "id"),
+        # CREATE INDEX idx_match_pep1_id ON match (upload_id, pep1_id);
+        # CREATE INDEX idx_match_pep2_id ON match (upload_id, pep2_id);
+        Index("idx_match_pep1_id", "upload_id", "pep1_id"),
+        Index("idx_match_pep2_id", "upload_id", "pep2_id"),
     )
 

--- a/parser/MzIdParser.py
+++ b/parser/MzIdParser.py
@@ -551,10 +551,10 @@ class MzIdParser:
                                              f'crosslinks, including multiple looplinks in peptide not supported')
 
             # link site validity check
-            if link_site1 is not None and link_site1 < 0:
-                raise MzIdParseException(f'Link site for peptide {pep_id} is negative')
-            if link_site2 is not None and link_site2 < 0:
-                raise MzIdParseException(f'Link site for peptide {pep_id} is negative')
+            # if link_site1 is not None and link_site1 < 0:
+            #     raise MzIdParseException(f'Link site for peptide {pep_id} is negative')
+            # if link_site2 is not None and link_site2 < 0:
+            #     raise MzIdParseException(f'Link site for peptide {pep_id} is negative')
 
             peptide_data = {
                 'id': peptide_index,

--- a/parser/process_dataset.py
+++ b/parser/process_dataset.py
@@ -4,6 +4,9 @@ import ftplib
 import gc
 import logging.config
 import os
+import sqlite3
+import traceback
+
 import orjson
 import shutil
 import socket
@@ -41,13 +44,19 @@ def parse_arguments():
     group.add_argument('-v', '--validate',
                        help='Validate mzIdentML file or files in specified folder against 1.2.0 or 1.3.0 XSD schema, '
                             'and check for other errors, including in referencing of peaklists. '
+                            'AND check that Seq elements are present for target proteins '
+                            '(this not being a requirement of the schema for validity). '
                             'If argument is directory all MzIdentmL files in it will be checked, '
-                            'but it exits after first fail.'
+                            'but it exits after first failure.'
                             'If its a specific file then this file will be checked.'
                             'The referenced peaklist files must be present alongside the MzIdentML files,'
-                            'contained in the same directory as them.')
+                            'i.e. contained in the same directory as them.')
     group.add_argument('--seqsandresiduepairs',
-                       help='output JSON with sequences and residue pairs')
+                       help='Output JSON with sequences and residue pairs,'
+                            'if argument is directory all MzIdentmL files in it will be read. '
+                            'If --temp option is given then the temp folder will be used for the sqlite DB file, '
+                            'otherwise an in-memory sqlite DB will be used. '
+                       )
 
     parser.add_argument('-i', '--identifier',
                         help='Identifier to use for dataset (if providing '
@@ -56,24 +65,14 @@ def parse_arguments():
     parser.add_argument('--dontdelete', action='store_true',
                         help="Don't delete downloaded data after processing")
     parser.add_argument('-t', '--temp', action='store_true',
-                        help='Temp folder to download data files into (default: ~/mzId_convertor_temp)')
+                        help='Temp folder to download data files into or to create temp sqlite DB in.'
+                             '(default: ~/mzId_convertor_temp)')
     parser.add_argument('-n', '--nopeaklist',
                         help='No peak list files available, only works in combination with --dir arg',
                         action='store_true')
     parser.add_argument('-w', '--writer', help='Save data to database(-w db) or API(-w api)')
 
     return parser.parse_args()
-
-
-def get_temp_dir(temp_arg):
-    """Returns the temporary directory for downloads."""
-    return os.path.expanduser(temp_arg) if temp_arg else os.path.expanduser('~/mzId_convertor_temp')
-
-
-def validate_writer_method(writer_method):
-    """Validates the writer method input."""
-    if writer_method and writer_method.lower() not in {'api', 'db'}:
-        raise ValueError('Writer method not supported! Please use "api" or "db".')
 
 
 def process_pxid(px_accessions, temp_dir, writer_method, dontdelete):
@@ -125,32 +124,136 @@ def json_sequences_and_residue_pairs(filepath, tmpdir):
     filepath : str
         The path to the mzIdentML file to be validated.
     tmpdir : str
-        The temporary directory to use for validation - an Sqlite DB is created here.
+        The temporary directory to use for validation - an Sqlite DB is created here if given,
+        otherwise an in-memory sqlite DB is used.
     """
+    local_dir = os.path.dirname(filepath)
+    file = os.path.basename(filepath)
+    filewithoutext = os.path.splitext(file)[0]
+    temp_database = os.path.join(str(tmpdir), f'{filewithoutext}.db')
 
-    print(orjson.dumps(sequences_and_residue_pairs(filepath, tmpdir)))
+    # tempdir is currently always set
+    if tmpdir:
+
+        # delete the temp database if it exists
+        if os.path.exists(temp_database):
+            os.remove(temp_database)
+
+        conn_str = f'sqlite:///{temp_database}'
+    # else: # wont currently work
+    #     conn_str = 'sqlite:///:memory:?cache=shared'
+
+    engine = create_engine(conn_str)
+
+    if os.path.isdir(filepath):
+        for file in os.listdir(filepath):
+            mzid_count = 0
+            if file.endswith(".mzid"):
+                mzid_count += 1
+                file_to_process = os.path.join(filepath, file)
+                read_sequences_and_residue_pairs(file_to_process, mzid_count, conn_str)
+    elif os.path.isfile(filepath):
+        if filepath.endswith(".mzid"):
+            read_sequences_and_residue_pairs(filepath, 0, conn_str)
+        else:
+            raise ValueError(f'Invalid file path (must end ".mzid"): {filepath}')
+    else:
+        raise ValueError(f'Invalid file or directory path: {filepath}')
+
+    with engine.connect() as conn:
+        try:
+            # get sequences
+            sql = text("""
+            SELECT dbseq.id, u.identification_file_name as file, dbseq.sequence, dbseq.accession
+            FROM upload AS u
+            JOIN dbsequence AS dbseq ON u.id = dbseq.upload_id
+            INNER JOIN peptideevidence pe ON dbseq.id = pe.dbsequence_id AND dbseq.upload_id = pe.upload_id
+            WHERE pe.is_decoy = false
+            GROUP BY dbseq.id, dbseq.sequence, dbseq.accession, u.identification_file_name;
+            """)
+            rs = conn.execute(sql)
+            seq_rows = rs.fetchall()
+            logging.info("Successfully fetched sequences")
+
+            # get residue pairs
+            # sql = text("""SELECT group_concat(si.id) as match_ids, group_concat(u.identification_file_name) as files,
+            # pe1.dbsequence_id as prot1, dbs1.accession as prot1_acc, (pe1.pep_start + mp1.link_site1 - 1) as pos1,
+            # pe2.dbsequence_id as prot2, dbs2.accession as prot2_acc, (pe2.pep_start + mp2.link_site1 - 1) as pos2
+            # FROM match si INNER JOIN
+            # modifiedpeptide mp1 ON si.pep1_id = mp1.id AND si.upload_id = mp1.upload_id INNER JOIN
+            # peptideevidence pe1 ON mp1.id = pe1.peptide_id AND mp1.upload_id = pe1.upload_id INNER JOIN
+            # dbsequence dbs1 ON pe1.dbsequence_id = dbs1.id AND pe1.upload_id = dbs1.upload_id INNER JOIN
+            # modifiedpeptide mp2 ON si.pep2_id = mp2.id AND si.upload_id = mp2.upload_id INNER JOIN
+            # peptideevidence pe2 ON mp2.id = pe2.peptide_id AND mp2.upload_id = pe2.upload_id INNER JOIN
+            # dbsequence dbs2 ON pe2.dbsequence_id = dbs2.id AND pe2.upload_id = dbs2.upload_id INNER JOIN
+            # upload u on u.id = si.upload_id
+            # WHERE mp1.link_site1 > 0 AND mp2.link_site1 > 0 AND pe1.is_decoy = false AND pe2.is_decoy = false
+            # AND si.pass_threshold = true
+            # GROUP BY pe1.dbsequence_id , dbs1.accession, (pe1.pep_start + mp1.link_site1 - 1), pe2.dbsequence_id, dbs2.accession , (pe2.pep_start + mp2.link_site1 - 1)
+            # ORDER BY pe1.dbsequence_id , (pe1.pep_start + mp1.link_site1 - 1), pe2.dbsequence_id, (pe2.pep_start + mp2.link_site1 - 1)
+            # ;""")
+            # rs = conn.execute(sql)
+            # rp_rows = rs.fetchall()
+            # logging.info("Successfully fetched residue pairs")
+
+        except Exception as error:
+            raise error
+        finally:
+            conn.close()
+
+    rp_rows = {}
+    try:
+        conn = sqlite3.connect(temp_database)
+        cur = conn.cursor()
+        sql = """SELECT group_concat(si.id) as match_ids, group_concat(u.identification_file_name) as files,
+            pe1.dbsequence_id as prot1, dbs1.accession as prot1_acc, (pe1.pep_start + mp1.link_site1 - 1) as pos1,
+            pe2.dbsequence_id as prot2, dbs2.accession as prot2_acc, (pe2.pep_start + mp2.link_site1 - 1) as pos2
+            FROM match si INNER JOIN
+            modifiedpeptide mp1 ON si.pep1_id = mp1.id AND si.upload_id = mp1.upload_id INNER JOIN
+            peptideevidence pe1 ON mp1.id = pe1.peptide_id AND mp1.upload_id = pe1.upload_id INNER JOIN
+            dbsequence dbs1 ON pe1.dbsequence_id = dbs1.id AND pe1.upload_id = dbs1.upload_id INNER JOIN
+            modifiedpeptide mp2 ON si.pep2_id = mp2.id AND si.upload_id = mp2.upload_id INNER JOIN
+            peptideevidence pe2 ON mp2.id = pe2.peptide_id AND mp2.upload_id = pe2.upload_id INNER JOIN
+            dbsequence dbs2 ON pe2.dbsequence_id = dbs2.id AND pe2.upload_id = dbs2.upload_id INNER JOIN
+            upload u on u.id = si.upload_id
+            WHERE mp1.link_site1 > 0 AND mp2.link_site1 > 0 AND pe1.is_decoy = false AND pe2.is_decoy = false
+            AND si.pass_threshold = true
+            GROUP BY pe1.dbsequence_id , dbs1.accession, (pe1.pep_start + mp1.link_site1 - 1), pe2.dbsequence_id, dbs2.accession , (pe2.pep_start + mp2.link_site1 - 1)
+            ORDER BY pe1.dbsequence_id , (pe1.pep_start + mp1.link_site1 - 1), pe2.dbsequence_id, (pe2.pep_start + mp2.link_site1 - 1)
+            ;"""
+        cur.execute(sql)
+        rp_rows = cur.fetchall()
+    except (Exception, sqlite3.DatabaseError) as error:
+        raise error
+    finally:
+        conn.close()
+
+    return{"sequences": seq_rows, "residue_pairs": rp_rows}
 
 
 def main():
     """Main function to execute script logic."""
     args = parse_arguments()
-    temp_dir = get_temp_dir(args.temp)
-    validate_writer_method(args.writer)
+    temp_dir = os.path.expanduser(args.temp) if args.temp else os.path.expanduser('~/mzId_convertor_temp')
+    if args.writer and args.writer.lower() not in {'api', 'db'}:
+        raise ValueError('Writer method not supported! Please use "api" or "db".')
+    writer_type = args.writer if args.writer else 'db'
 
     try:
         if args.pxid:
-            process_pxid(args.pxid, temp_dir, args.writer, args.dontdelete)
+            process_pxid(args.pxid, temp_dir, writer_type, args.dontdelete)
         elif args.ftp:
-            process_ftp(args.ftp, temp_dir, args.identifier, args.writer, args.dontdelete)
+            process_ftp(args.ftp, temp_dir, args.identifier, writer_type, args.dontdelete)
         elif args.dir:
-            process_dir(args.dir, args.identifier, args.writer, args.nopeaklist)
+            process_dir(args.dir, args.identifier, writer_type, args.nopeaklist)
         elif args.validate:
             validate(args.validate, temp_dir)
         elif args.seqsandresiduepairs:
-            json_sequences_and_residue_pairs(args.seqsandresiduepairs, temp_dir)
+            print(json_sequences_and_residue_pairs(args.seqsandresiduepairs, temp_dir))
         sys.exit(0)
     except Exception as ex:
         logger.error(ex)
+        traceback.print_exc()
         sys.exit(1)
 
 
@@ -322,6 +425,9 @@ def validate_file(filepath, tmpdir):
     local_dir = os.path.dirname(filepath)
     file = os.path.basename(filepath)
 
+    if not file.endswith(".mzid"):
+        raise ValueError(f'Invalid file path (must end ".mzid"): {filepath}')
+
     if schema_validate(filepath):
         print(f'File {filepath} is schema valid.')
 
@@ -332,6 +438,10 @@ def validate_file(filepath, tmpdir):
             os.remove(test_database)
         conn_str = f'sqlite:///{test_database}'
         engine = create_engine(conn_str)
+
+        # switch on Foreign Key Enforcement
+        with engine.connect() as conn:
+            conn.execute(text("PRAGMA foreign_keys = ON;"))
 
         writer = DatabaseWriter(conn_str, upload_id=1, pxid="Validation")
         id_parser = SqliteMzIdParser(os.path.join(local_dir, file), local_dir, local_dir, writer, logger)
@@ -349,7 +459,7 @@ def validate_file(filepath, tmpdir):
     return True
 
 
-def sequences_and_residue_pairs(filepath, tmpdir):
+def read_sequences_and_residue_pairs(filepath, upload_id, conn_str):
     """
     get sequences and residue pairs from mzIdentML files
 
@@ -357,61 +467,27 @@ def sequences_and_residue_pairs(filepath, tmpdir):
     ----------
     filepath : str
         The path to the mzIdentML file to be validated.
-    tmpdir : str
-        The temporary directory to use for validation - an Sqlite DB is created here.
+    upload_id : int
+        The upload id to use for the sequences and residue pairs.
+    sqlite_engine : sqlalchemy.engine.base.Connection
+        The sqlite engine to use for the sequences and residue pairs.
 
     Returns
     -------
-    objects
-          """
-
-    # if os.path.isdir(filepath):
-    #     for file in os.listdir(filepath):
-    #         if file.endswith(".mzid"):
-    #             file_to_process = os.path.join(filepath, file)
-    #             sequences_and_residue_pairs(file_to_process, tmpdir)
-
+    None
+    """
 
     local_dir = os.path.dirname(filepath)
-    file = os.path.basename(filepath)
-
-    filewithoutext = os.path.splitext(file)[0]
-    test_database = os.path.join(str(tmpdir), f'{filewithoutext}.db')
-    # delete the test database if it exists
-    if os.path.exists(test_database):
-        os.remove(test_database)
-    conn_str = f'sqlite:///{test_database}'
-    engine = create_engine(conn_str)
-
-    writer = DatabaseWriter(conn_str, upload_id=1, pxid="Validation")
-    id_parser = SqliteMzIdParser(os.path.join(local_dir, file), local_dir, local_dir, writer, logger)
+    writer = DatabaseWriter(conn_str, upload_id, pxid="Validation")
+    id_parser = SqliteMzIdParser(filepath, local_dir, local_dir, writer, logger)
     try:
         id_parser.parse()
     except Exception as e:
         print(f"Error parsing {filepath}")
-        print(e)
+        raise(e)
 
-    with engine.connect() as conn:
-        try:
-            sql = text("""
-            SELECT dbseq.id, u.identification_file_name as file, dbseq.sequence, dbseq.accession
-            FROM upload AS u
-            JOIN dbsequence AS dbseq ON u.id = dbseq.upload_id
-            INNER JOIN peptideevidence pe ON dbseq.id = pe.dbsequence_id AND dbseq.upload_id = pe.upload_id
-            WHERE u.id = 1
-            AND pe.is_decoy = false
-            GROUP BY dbseq.id, dbseq.sequence, dbseq.accession, u.identification_file_name;
-            """)
-            rs = conn.execute(sql)
-            mzid_rows = rs.fetchall()
 
-            logging.info("Successfully fetched sequences")
-        except Exception as error:
-            logging.error(error)
-        finally:
-            logging.info('Database connection closed.')
 
-    return mzid_rows
 
 
 

--- a/parser/process_dataset.py
+++ b/parser/process_dataset.py
@@ -4,7 +4,6 @@ import ftplib
 import gc
 import logging.config
 import os
-import sqlite3
 import traceback
 
 import shutil
@@ -96,7 +95,22 @@ def process_dir(local_dir, project_identifier, writer_method, nopeaklist):
 
 
 def validate(validate_arg, tmpdir):
-    """Validates mzIdentML files against the XSD schema, then checks for other errors."""
+    """Validates mzIdentML files against the XSD schema, then checks for other errors.
+    This includes checking that Seq elements are present for target proteins,
+    even though omitting them is technically valid.
+    Prints out results.
+    Parameters
+    ----------
+    validate_arg : str
+        The path to the mzIdentML file or directory to be validated.
+        tmpdir : str
+        The temporary directory to use for validation - an Sqlite DB is created here if given,
+        otherwise an in-memory sqlite DB is used.
+
+    Returns
+    -------
+    None
+    """
     if os.path.isdir(validate_arg):
         print(f'Validating directory: {validate_arg}')
         for file in os.listdir(validate_arg):
@@ -118,7 +132,17 @@ def validate(validate_arg, tmpdir):
 
 
 def json_sequences_and_residue_pairs(filepath, tmpdir):
+    """Returns json of sequences and residue pairs from mzIdentML files.
+    Parameters
+    ----------
+    filepath : str
+        The path to the mzIdentML file to be validated.
+    tmpdir : str
+        The temporary directory to use for validation - an Sqlite DB is created here if given,
+        otherwise an in-memory sqlite DB is used.
+    """
     return orjson.dumps(sequences_and_residue_pairs(filepath, tmpdir))
+
 
 def sequences_and_residue_pairs(filepath, tmpdir):
     """Prints json of sequences and residue pairs from mzIdentML files
@@ -136,14 +160,13 @@ def sequences_and_residue_pairs(filepath, tmpdir):
 
     # tempdir is currently always set
     if tmpdir:
-
         # delete the temp database if it exists
         if os.path.exists(temp_database):
             os.remove(temp_database)
 
         conn_str = f'sqlite:///{temp_database}'
-    # else: # wont currently work
-    #     conn_str = 'sqlite:///:memory:?cache=shared'
+    else: # not working
+        conn_str = 'sqlite:///:memory:?cache=shared'
 
     engine = create_engine(conn_str)
 
@@ -184,18 +207,18 @@ def sequences_and_residue_pairs(filepath, tmpdir):
             pe1.dbsequence_id as prot1, dbs1.accession as prot1_acc, (pe1.pep_start + mp1.link_site1 - 1) as pos1,
             pe2.dbsequence_id as prot2, dbs2.accession as prot2_acc, (pe2.pep_start + mp2.link_site1 - 1) as pos2
             FROM match si INNER JOIN
-            modifiedpeptide mp1 ON si.pep1_id = mp1.id AND si.upload_id = mp1.upload_id INNER JOIN
-            peptideevidence pe1 ON mp1.id = pe1.peptide_id AND mp1.upload_id = pe1.upload_id INNER JOIN
-            dbsequence dbs1 ON pe1.dbsequence_id = dbs1.id AND pe1.upload_id = dbs1.upload_id INNER JOIN
-            modifiedpeptide mp2 ON si.pep2_id = mp2.id AND si.upload_id = mp2.upload_id INNER JOIN
-            peptideevidence pe2 ON mp2.id = pe2.peptide_id AND mp2.upload_id = pe2.upload_id INNER JOIN
-            dbsequence dbs2 ON pe2.dbsequence_id = dbs2.id AND pe2.upload_id = dbs2.upload_id INNER JOIN
+            modifiedpeptide mp1 ON si.upload_id = mp1.upload_id AND si.pep1_id = mp1.id INNER JOIN
+            peptideevidence pe1 ON mp1.upload_id = pe1.upload_id AND  mp1.id = pe1.peptide_id INNER JOIN
+            dbsequence dbs1 ON pe1.upload_id = dbs1.upload_id AND pe1.dbsequence_id = dbs1.id INNER JOIN
+            modifiedpeptide mp2 ON si.upload_id = mp2.upload_id AND si.pep2_id = mp2.id INNER JOIN
+            peptideevidence pe2 ON mp2.upload_id = pe2.upload_id AND mp2.id = pe2.peptide_id INNER JOIN
+            dbsequence dbs2 ON pe2.upload_id = dbs2.upload_id AND pe2.dbsequence_id = dbs2.id INNER JOIN
             upload u on u.id = si.upload_id
             WHERE mp1.link_site1 > 0 AND mp2.link_site1 > 0 AND pe1.is_decoy = false AND pe2.is_decoy = false
             AND si.pass_threshold = true
-            GROUP BY pe1.dbsequence_id , dbs1.accession, (pe1.pep_start + mp1.link_site1 - 1), pe2.dbsequence_id, dbs2.accession , (pe2.pep_start + mp2.link_site1 - 1)
+            GROUP BY pe1.dbsequence_id , dbs1.accession, pos1, pe2.dbsequence_id, dbs2.accession , pos2
+            ORDER BY pe1.dbsequence_id , pos1, pe2.dbsequence_id, pos2
             ;""")
-            # ORDER BY pe1.dbsequence_id , (pe1.pep_start + mp1.link_site1 - 1), pe2.dbsequence_id, (pe2.pep_start + mp2.link_site1 - 1)
             start_time = time.time()
             rs = conn.execute(sql)
             elapsed_time = time.time() - start_time
@@ -208,7 +231,7 @@ def sequences_and_residue_pairs(filepath, tmpdir):
         finally:
             conn.close()
 
-    return{"sequences": seq_rows, "residue_pairs": rp_rows}
+    return {"sequences": seq_rows, "residue_pairs": rp_rows}
 
 
 def main():
@@ -468,10 +491,6 @@ def read_sequences_and_residue_pairs(filepath, upload_id, conn_str):
     except Exception as e:
         print(f"Error parsing {filepath}")
         raise e
-
-
-
-
 
 
 if __name__ == "__main__":

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ def get_version(rel_path):
 
 setup(
     name="xi-mzidentml-converter",
-    version="0.2.5",
+    version="0.2.6a1",
     description="xi-mzidentml-converter uses pyteomics (https://pyteomics.readthedocs.io/en/latest/index.html) to "
                 "parse mzIdentML files (v1.2.0) and extract crosslink information. Results are written to a "
                 "relational database (PostgreSQL or SQLite) using sqlalchemy.",

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ def get_version(rel_path):
 
 setup(
     name="xi-mzidentml-converter",
-    version="0.2.6a2",
+    version="0.2.6a3",
     description="xi-mzidentml-converter uses pyteomics (https://pyteomics.readthedocs.io/en/latest/index.html) to "
                 "parse mzIdentML files (v1.2.0) and extract crosslink information. Results are written to a "
                 "relational database (PostgreSQL or SQLite) using sqlalchemy.",

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ def get_version(rel_path):
 
 setup(
     name="xi-mzidentml-converter",
-    version="0.2.6a1",
+    version="0.2.6a2",
     description="xi-mzidentml-converter uses pyteomics (https://pyteomics.readthedocs.io/en/latest/index.html) to "
                 "parse mzIdentML files (v1.2.0) and extract crosslink information. Results are written to a "
                 "relational database (PostgreSQL or SQLite) using sqlalchemy.",

--- a/tests/test_MzIdParser_ecoli_dsso.py
+++ b/tests/test_MzIdParser_ecoli_dsso.py
@@ -1254,11 +1254,11 @@ def test_sqlite_mgf_xispec_mzid_parser(tmpdir):
     id_parser = parse_mzid_into_sqlite_xispec(mzid, peak_list_folder, tmpdir, logger, engine)
 
     with engine.connect() as conn:
-        # DBSequence - not written for xiSPEC
+        # DBSequence
         stmt = Table("DBSequence", id_parser.writer.meta, autoload_with=id_parser.writer.engine,
                      quote=False).select()
         rs = conn.execute(stmt)
-        assert len(rs.fetchall()) == 0
+        assert len(rs.fetchall()) == 12
 
         # Modification - parsed from <SearchModification>s
         stmt = Table("SearchModification", id_parser.writer.meta, autoload_with=id_parser.writer.engine,
@@ -1327,11 +1327,11 @@ def test_sqlite_mzml_xispec_mzid_parser(tmpdir):
     id_parser = parse_mzid_into_sqlite_xispec(mzid, peak_list_folder, tmpdir, logger, engine)
 
     with engine.connect() as conn:
-        # DBSequence - not written for xiSPEC
+        # DBSequence
         stmt = Table("DBSequence", id_parser.writer.meta, autoload_with=id_parser.writer.engine,
                      quote=False).select()
         rs = conn.execute(stmt)
-        assert len(rs.fetchall()) == 0
+        assert len(rs.fetchall()) == 12
 
         # Modification - parsed from <SearchModification>s
         stmt = Table("SearchModification", id_parser.writer.meta, autoload_with=id_parser.writer.engine,

--- a/tests/test_MzIdParser_matrixscience.py
+++ b/tests/test_MzIdParser_matrixscience.py
@@ -128,58 +128,58 @@ def compare_enzyme(results):
     assert results[0].accession == "MS:1001313"
 
 
-def test_psql_matrixscience_mzid_parser(tmpdir, db_info, use_database, engine):
-    # file paths
-    fixtures_dir = os.path.join(os.path.dirname(__file__), 'fixtures', 'mzid_parser')
-    mzid = os.path.join(fixtures_dir, 'F002553.mzid')
-    peak_list_folder = False
-
-    id_parser = parse_mzid_into_postgresql(mzid, peak_list_folder, tmpdir, logger, use_database,
-                                           engine)
-
-    with engine.connect() as conn:
-        # Match
-        stmt = Table("match", id_parser.writer.meta, autoload_with=id_parser.writer.engine,
-                     quote=False).select()
-        rs = conn.execute(stmt)
-        compare_spectrum_identification(rs.fetchall())
-
-        # DBSequence
-        stmt = Table("dbsequence", id_parser.writer.meta, autoload_with=id_parser.writer.engine,
-                     quote=False).select()
-        rs = conn.execute(stmt)
-        compare_db_sequence(rs.fetchall())
-
-        # Modification - parsed from <SearchModification>s
-        stmt = Table("searchmodification", id_parser.writer.meta, autoload_with=id_parser.writer.engine,
-                     quote=False).select()
-        rs = conn.execute(stmt)
-        compare_modification(rs.fetchall())
-
-        # Enzyme - parsed from SpectrumIdentificationProtocols
-        stmt = Table("enzyme", id_parser.writer.meta, autoload_with=id_parser.writer.engine,
-                     quote=False).select()
-        rs = conn.execute(stmt)
-        compare_enzyme(rs.fetchall())
-
-        # PeptideEvidence
-        stmt = Table("peptideevidence", id_parser.writer.meta, autoload_with=id_parser.writer.engine,
-                     quote=False).select()
-        rs = conn.execute(stmt)
-        compare_peptide_evidence(rs.fetchall())
-
-        # ModifiedPeptide
-        stmt = Table("modifiedpeptide", id_parser.writer.meta, autoload_with=id_parser.writer.engine,
-                     quote=False).select()
-        rs = conn.execute(stmt)
-        compare_modified_peptide(rs.fetchall())
-
-        # Spectrum (peak_list_folder = False)
-        stmt = Table("spectrum", id_parser.writer.meta, autoload_with=id_parser.writer.engine,
-                     quote=False).select()
-        rs = conn.execute(stmt)
-        assert len(rs.fetchall()) == 0
-
-        # ToDo: remaining Tables
-
-    engine.dispose()
+# def test_psql_matrixscience_mzid_parser(tmpdir, db_info, use_database, engine):
+#     # file paths
+#     fixtures_dir = os.path.join(os.path.dirname(__file__), 'fixtures', 'mzid_parser')
+#     mzid = os.path.join(fixtures_dir, 'F002553.mzid')
+#     peak_list_folder = False
+#
+#     id_parser = parse_mzid_into_postgresql(mzid, peak_list_folder, tmpdir, logger, use_database,
+#                                            engine)
+#
+#     with engine.connect() as conn:
+#         # Match
+#         stmt = Table("match", id_parser.writer.meta, autoload_with=id_parser.writer.engine,
+#                      quote=False).select()
+#         rs = conn.execute(stmt)
+#         compare_spectrum_identification(rs.fetchall())
+#
+#         # DBSequence
+#         stmt = Table("dbsequence", id_parser.writer.meta, autoload_with=id_parser.writer.engine,
+#                      quote=False).select()
+#         rs = conn.execute(stmt)
+#         compare_db_sequence(rs.fetchall())
+#
+#         # Modification - parsed from <SearchModification>s
+#         stmt = Table("searchmodification", id_parser.writer.meta, autoload_with=id_parser.writer.engine,
+#                      quote=False).select()
+#         rs = conn.execute(stmt)
+#         compare_modification(rs.fetchall())
+#
+#         # Enzyme - parsed from SpectrumIdentificationProtocols
+#         stmt = Table("enzyme", id_parser.writer.meta, autoload_with=id_parser.writer.engine,
+#                      quote=False).select()
+#         rs = conn.execute(stmt)
+#         compare_enzyme(rs.fetchall())
+#
+#         # PeptideEvidence
+#         stmt = Table("peptideevidence", id_parser.writer.meta, autoload_with=id_parser.writer.engine,
+#                      quote=False).select()
+#         rs = conn.execute(stmt)
+#         compare_peptide_evidence(rs.fetchall())
+#
+#         # ModifiedPeptide
+#         stmt = Table("modifiedpeptide", id_parser.writer.meta, autoload_with=id_parser.writer.engine,
+#                      quote=False).select()
+#         rs = conn.execute(stmt)
+#         compare_modified_peptide(rs.fetchall())
+#
+#         # Spectrum (peak_list_folder = False)
+#         stmt = Table("spectrum", id_parser.writer.meta, autoload_with=id_parser.writer.engine,
+#                      quote=False).select()
+#         rs = conn.execute(stmt)
+#         assert len(rs.fetchall()) == 0
+#
+#         # ToDo: remaining Tables
+#
+#     engine.dispose()

--- a/tests/test_MzIdParser_matrixscience2.py
+++ b/tests/test_MzIdParser_matrixscience2.py
@@ -128,58 +128,58 @@ def compare_enzyme(results):
     assert results[0].accession == "MS:1001313"
 
 
-def test_psql_matrixscience_mzid_parser(tmpdir, db_info, use_database, engine):
-    # file paths
-    fixtures_dir = os.path.join(os.path.dirname(__file__), 'fixtures', 'mzid_parser')
-    mzid = os.path.join(fixtures_dir, 'F002553_samesets.mzid')
-    peak_list_folder = False
-
-    id_parser = parse_mzid_into_postgresql(mzid, peak_list_folder, tmpdir, logger, use_database,
-                                           engine)
-
-    with engine.connect() as conn:
-        # Match
-        stmt = Table("match", id_parser.writer.meta, autoload_with=id_parser.writer.engine,
-                     quote=False).select()
-        rs = conn.execute(stmt)
-        compare_spectrum_identification(rs.fetchall())
-
-        # DBSequence
-        stmt = Table("dbsequence", id_parser.writer.meta, autoload_with=id_parser.writer.engine,
-                     quote=False).select()
-        rs = conn.execute(stmt)
-        compare_db_sequence(rs.fetchall())
-
-        # Modification - parsed from <SearchModification>s
-        stmt = Table("searchmodification", id_parser.writer.meta, autoload_with=id_parser.writer.engine,
-                     quote=False).select()
-        rs = conn.execute(stmt)
-        compare_modification(rs.fetchall())
-
-        # Enzyme - parsed from SpectrumIdentificationProtocols
-        stmt = Table("enzyme", id_parser.writer.meta, autoload_with=id_parser.writer.engine,
-                     quote=False).select()
-        rs = conn.execute(stmt)
-        compare_enzyme(rs.fetchall())
-
-        # PeptideEvidence
-        stmt = Table("peptideevidence", id_parser.writer.meta, autoload_with=id_parser.writer.engine,
-                     quote=False).select()
-        rs = conn.execute(stmt)
-        compare_peptide_evidence(rs.fetchall())
-
-        # ModifiedPeptide
-        stmt = Table("modifiedpeptide", id_parser.writer.meta, autoload_with=id_parser.writer.engine,
-                     quote=False).select()
-        rs = conn.execute(stmt)
-        compare_modified_peptide(rs.fetchall())
-
-        # Spectrum (peak_list_folder = False)
-        stmt = Table("spectrum", id_parser.writer.meta, autoload_with=id_parser.writer.engine,
-                     quote=False).select()
-        rs = conn.execute(stmt)
-        assert len(rs.fetchall()) == 0
-
-        # ToDo: remaining Tables
-
-    engine.dispose()
+# def test_psql_matrixscience_mzid_parser(tmpdir, db_info, use_database, engine):
+#     # file paths
+#     fixtures_dir = os.path.join(os.path.dirname(__file__), 'fixtures', 'mzid_parser')
+#     mzid = os.path.join(fixtures_dir, 'F002553_samesets.mzid')
+#     peak_list_folder = False
+#
+#     id_parser = parse_mzid_into_postgresql(mzid, peak_list_folder, tmpdir, logger, use_database,
+#                                            engine)
+#
+#     with engine.connect() as conn:
+#         # Match
+#         stmt = Table("match", id_parser.writer.meta, autoload_with=id_parser.writer.engine,
+#                      quote=False).select()
+#         rs = conn.execute(stmt)
+#         compare_spectrum_identification(rs.fetchall())
+#
+#         # DBSequence
+#         stmt = Table("dbsequence", id_parser.writer.meta, autoload_with=id_parser.writer.engine,
+#                      quote=False).select()
+#         rs = conn.execute(stmt)
+#         compare_db_sequence(rs.fetchall())
+#
+#         # Modification - parsed from <SearchModification>s
+#         stmt = Table("searchmodification", id_parser.writer.meta, autoload_with=id_parser.writer.engine,
+#                      quote=False).select()
+#         rs = conn.execute(stmt)
+#         compare_modification(rs.fetchall())
+#
+#         # Enzyme - parsed from SpectrumIdentificationProtocols
+#         stmt = Table("enzyme", id_parser.writer.meta, autoload_with=id_parser.writer.engine,
+#                      quote=False).select()
+#         rs = conn.execute(stmt)
+#         compare_enzyme(rs.fetchall())
+#
+#         # PeptideEvidence
+#         stmt = Table("peptideevidence", id_parser.writer.meta, autoload_with=id_parser.writer.engine,
+#                      quote=False).select()
+#         rs = conn.execute(stmt)
+#         compare_peptide_evidence(rs.fetchall())
+#
+#         # ModifiedPeptide
+#         stmt = Table("modifiedpeptide", id_parser.writer.meta, autoload_with=id_parser.writer.engine,
+#                      quote=False).select()
+#         rs = conn.execute(stmt)
+#         compare_modified_peptide(rs.fetchall())
+#
+#         # Spectrum (peak_list_folder = False)
+#         stmt = Table("spectrum", id_parser.writer.meta, autoload_with=id_parser.writer.engine,
+#                      quote=False).select()
+#         rs = conn.execute(stmt)
+#         assert len(rs.fetchall()) == 0
+#
+#         # ToDo: remaining Tables
+#
+#     engine.dispose()


### PR DESCRIPTION
### **User description**
validation works i think, 
but getting sequences and residue pairs doesn't work so well


___

### **PR Type**
enhancement, tests


___

### **Description**
- Enhanced the `MzIdParser` to include a new dictionary for database sequences and added a method to ensure target proteins have sequences.
- Improved the argument parsing and database handling in `process_dataset.py`, including better logging and error handling.
- Updated the version number in `setup.py` to `0.2.6a3`.
- Modified tests to reflect changes in DBSequence handling, including commenting out certain PostgreSQL parsing tests.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>MzIdParser.py</strong><dd><code>Enhance parsing logic and add sequence validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

parser/MzIdParser.py

<li>Added a dictionary <code>dbseqs</code> to store database sequences.<br> <li> Implemented <code>check_target_proteins_have_sequence</code> to ensure target <br>proteins have sequences.<br> <li> Removed link site validity checks.<br> <li> Updated peptide evidence parsing to mark decoy sequences.<br>


</details>


  </td>
  <td><a href="https://github.com/PRIDE-Archive/xi-mzidentml-converter/pull/84/files#diff-02bb8e9514e83929d0cfea8db1032331365d0442ac3944b60ba8ca30979cfe08">+28/-6</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>process_dataset.py</strong><dd><code>Improve argument parsing and database handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

parser/process_dataset.py

<li>Improved argument parsing for sequence and residue pair output.<br> <li> Added detailed logging and error handling for sequence fetching.<br> <li> Enhanced SQLite database handling for temporary storage.<br> <li> Updated validation logic to ensure file extensions are correct.<br>


</details>


  </td>
  <td><a href="https://github.com/PRIDE-Archive/xi-mzidentml-converter/pull/84/files#diff-836b63c3d0a5cfd84adb440dc94f91f141016f6d45fe4e2857056753fe01dddf">+147/-68</a></td>

</tr>                    
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>setup.py</strong><dd><code>Update version number to 0.2.6a3</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

setup.py

- Updated the version number to `0.2.6a3`.



</details>


  </td>
  <td><a href="https://github.com/PRIDE-Archive/xi-mzidentml-converter/pull/84/files#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_MzIdParser_ecoli_dsso.py</strong><dd><code>Update test assertions for DBSequence entries</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_MzIdParser_ecoli_dsso.py

- Modified test to check for 12 DBSequence entries instead of 0.



</details>


  </td>
  <td><a href="https://github.com/PRIDE-Archive/xi-mzidentml-converter/pull/84/files#diff-85f1a161e859f228712c70fa01300f253115ebd69d7adc7f46d06ca895833ba2">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>test_MzIdParser_matrixscience.py</strong><dd><code>Comment out PostgreSQL parsing test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_MzIdParser_matrixscience.py

- Commented out the test for PostgreSQL parsing.



</details>


  </td>
  <td><a href="https://github.com/PRIDE-Archive/xi-mzidentml-converter/pull/84/files#diff-6eb6576c4f21088c0897498a807795fdbf435ac3631200bc258a9f24a1f5d92e">+55/-55</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>test_MzIdParser_matrixscience2.py</strong><dd><code>Comment out PostgreSQL parsing test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_MzIdParser_matrixscience2.py

- Commented out the test for PostgreSQL parsing.



</details>


  </td>
  <td><a href="https://github.com/PRIDE-Archive/xi-mzidentml-converter/pull/84/files#diff-e4b16fbad656af7ddcae91263df7b1035b0d4faea5b8498a9df269ba96862939">+55/-55</a>&nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information