### PR TITLE
Enable calling the parser as module and introduced a wrapper in the main 

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,14 @@ PYPI instructions: https://packaging.python.org/en/latest/tutorials/installing-p
 proceess_dataset.py is the entry point and running it with the -h option will give a list of options.
 
 ```
-python process_dataset.py -h
+python parser.py -h
 ```
+
+alternative:
+```
+python -m parser -h
+```
+
 
 ### 1. Validate a dataset
 
@@ -50,10 +56,10 @@ temporary folder which is used in the validation process, the temporary folder c
 
 Examples:
 ```
-python process_dataset.py -v ~/mydata
+python parser.py -v ~/mydata
 ```
 ```
-python process_dataset.py -v ~/mydata/mymzid.mzid -t ~/mytempdir
+python parser.py -v ~/mydata/mymzid.mzid -t ~/mytempdir
 ```
 
 The result is written to the console. If the data fails validation but the error message is not informative,
@@ -67,15 +73,15 @@ file or a directory containing multiple mzIdentML files, in which case all of th
 
 Examples:
 ```
-python process_dataset.py --seqsandresiduepairs ~/mydata -t ~/mytempdir
+python parser.py --seqsandresiduepairs ~/mydata -t ~/mytempdir
 ```
 
 ```
-python process_dataset.py --seqsandresiduepairs ~/mydata/mymzid.mzid
+python parser.py --seqsandresiduepairs ~/mydata/mymzid.mzid
 ```
 
 It can also be accessed programitically by using the 
-`json_sequences_and_residue_pairs(filepath, tmpdir)` function in process_dataset.py. 
+`json_sequences_and_residue_pairs(filepath, tmpdir)` function in parser.py. 
 
 ### 3. populate the xiview-api database
 
@@ -126,7 +132,7 @@ python database/create_db_schema.py
 #### Populate the database
 To parse a test dataset:
 ```
-python process_dataset.py -d ~/PXD038060
+python parser.py -d ~/PXD038060
 ```
 
 The command line options that populate the database are -d, -f and -p. Only one of these can be used.

--- a/parser.py
+++ b/parser.py
@@ -1,0 +1,4 @@
+from parser.process_dataset import main
+
+if __name__ == "__main__":
+    main()

--- a/parser/__main__.py
+++ b/parser/__main__.py
@@ -1,0 +1,4 @@
+from parser.process_dataset import main
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### **PR Type**
enhancement, documentation


___

### **Description**
- Added module entry point for `parser` to enable `python -m parser` usage.

- Introduced `parser.py` wrapper for easier script execution.

- Updated documentation to reflect new usage patterns.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>parser.py</strong><dd><code>Add wrapper script for direct execution</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

parser.py

<li>Added wrapper script to call <code>main</code> from <code>parser.process_dataset</code>.<br> <li> Enables running parser via <code>python parser.py</code>.


</details>


  </td>
  <td><a href="https://github.com/PRIDE-Archive/xi-mzidentml-converter/pull/89/files#diff-df00b01568933a06c611778d2d70679891ebf6e950241d03bb2aa27f3e196fe0">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>__main__.py</strong><dd><code>Add module entry point for parser</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

parser/__main__.py

<li>Added <code>__main__.py</code> to allow running as a module with <code>python -m parser</code>.<br> <li> Calls the same <code>main</code> function as the wrapper.


</details>


  </td>
  <td><a href="https://github.com/PRIDE-Archive/xi-mzidentml-converter/pull/89/files#diff-b74186915aa38039e66a2ce8c057454c9a505b703d16fe3b45094f2d230722ad">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Update documentation for new entry points</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<li>Updated usage instructions to use <code>python parser.py</code> and <code>python -m </code><br><code>parser</code>.<br> <li> Adjusted all code examples to new entry points.<br> <li> Clarified programmatic usage reference to <code>parser.py</code>.


</details>


  </td>
  <td><a href="https://github.com/PRIDE-Archive/xi-mzidentml-converter/pull/89/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+13/-7</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated usage instructions and command-line examples in the README to reference the new entry point script.
  - Clarified alternative invocation methods and updated references to programmatic access.

- **New Features**
  - Added new command-line entry points, allowing users to run the tool directly via the new script or package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->