### PR TITLE
change how exit is called is schema validation fails

### DIFF
--- a/parser/process_dataset.py
+++ b/parser/process_dataset.py
@@ -429,7 +429,7 @@ def convert_dir(local_dir, project_identifier, writer_method, nopeaklist=False):
                     raise e
             else:
                 print(f'File {file} is schema invalid.')
-                exit()
+                sys.exit(1)
 
 
 

--- a/parser/schema_validate.py
+++ b/parser/schema_validate.py
@@ -9,6 +9,7 @@ def schema_validate(xml_file):
     :param xml_file: Path to the mzIdentML file.
     :return: True if the XML is valid, False otherwise.
     """
+
     # Parse the XML file
     with open(xml_file, 'r') as xml:
         xml_doc = etree.parse(xml)

--- a/parser/schema_validate.py
+++ b/parser/schema_validate.py
@@ -9,7 +9,6 @@ def schema_validate(xml_file):
     :param xml_file: Path to the mzIdentML file.
     :return: True if the XML is valid, False otherwise.
     """
-
     # Parse the XML file
     with open(xml_file, 'r') as xml:
         xml_doc = etree.parse(xml)


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Replace bare `exit()` with `sys.exit(1)` in schema validation


___

### **Changes diagram**

```mermaid
flowchart LR
  A["Schema validation fails"] --> B["Replace exit()"] --> C["sys.exit(1) with error code"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>process_dataset.py</strong><dd><code>Fix exit call for schema validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

parser/process_dataset.py

<li>Replace bare <code>exit()</code> call with <code>sys.exit(1)</code> when schema validation fails


</details>


  </td>
  <td><a href="https://github.com/PRIDE-Archive/mzidentml-reader/pull/92/files#diff-836b63c3d0a5cfd84adb440dc94f91f141016f6d45fe4e2857056753fe01dddf">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling to ensure the program exits with an appropriate error status when a file fails schema validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->