### PR TITLE
Update exclusion list (122 new entries)

### DIFF
--- a/mzidentml_data_exclusions/exclusion_list.csv
+++ b/mzidentml_data_exclusions/exclusion_list.csv
@@ -1,2 +1,123 @@
 ProjectAccession,FIle, ExclusionReason
-PXD019771, 200115_A4.mzid, XML syntax error in 200115_A4.mzid
+PXD019771, 200115_A4.mzid, XML syntax error in 200115_A4.mzidPXD001593,83NWI-US_1apr2010undigestedF059907.mzid.gz,No MS:1002511 CV param found
+PXD001677,result_DynamicDBReduction.mzid.gz,"Validating file result_DynamicDBReduction.mzid. | Sorry, we're only supporting 1.2.0 and 1.3.0 (the ones that contain crosslinks). Rejected schema file: mzIdentML1.1.0.xsd | File result_DynamicDBReduction.mzid is schema invalid."
+PXD003532,Experimentmaxquantresults_18_4w1fromQEPlus2_12172015_18_4w1.mzid.gz,No MS:1002511 CV param found
+PXD003718,Baits_ORF4259Nter_ORF4259Cterandwildtype_scaffold_mascot_giardia.mzid.gz,No MS:1002511 CV param found
+PXD004473,CW2177_mzIdentML.mzid,No MS:1002511 CV param found
+PXD004583,20131210sr_5587_rev_c_3F192213.mzid.gz,No MS:1002511 CV param found
+PXD004722,p1.mzid,No MS:1002511 CV param found
+PXD005461,OBJ7527_F059818.mzid.gz,No MS:1002511 CV param found
+PXD005786,272218_BICR_ZNF532_NBioTAP_Input.mzid,No MS:1002511 CV param found
+PXD006079,272099_Barry_CG_Strep.mzid,No MS:1002511 CV param found
+PXD006574,monomerResults.mzid.gz,"Validating file monomerResults.mzid. | Sorry, we're only supporting 1.2.0 and 1.3.0 (the ones that contain crosslinks). Rejected schema file: mzIdentML1.1.0.xsd | File monomerResults.mzid is schema invalid."
+PXD006938,2_NFS1-Fxn-IscU_MarkleyF016506.mzid.gz,No MS:1002511 CV param found
+PXD007716,F074077.mzid.gz,No MS:1002511 CV param found
+PXD007836,peptides_1_1_0.mzid.gz,No MS:1002511 CV param found
+PXD008680,20140107U2OSCytoD_B_F019267.mzid,No MS:1002511 CV param found
+PXD009239,FileName_SM-PRI-STD2.rawF031165.mzid.gz,No MS:1002511 CV param found
+PXD009641,ID16362_01_E749_3008_030315F056135.mzid.gz,No MS:1002511 CV param found
+PXD012225,Mudpit_20181104_AIssaian_Clot_Frac_xLink_6_HCDFTF101833.mzid.gz,No MS:1002511 CV param found
+PXD012466,mapeixiang-NSSO-3.mzid.gz,No MS:1002511 CV param found
+PXD012753,F009919_MouseSkinDermis_Urea_YoungOldOVX.mzid.gz,No MS:1002511 CV param found
+PXD012754,F010084_MouseSkinDermis_NaCl_YoungOld.mzid.gz,No MS:1002511 CV param found
+PXD012759,PCR3.mzid,No MS:1002511 CV param found
+PXD013890,20151203lc_8000_7723_2F228836.mzid.gz,No MS:1002511 CV param found
+PXD013896,20170823lc_9968_17195_7F255991.mzid.gz,No MS:1002511 CV param found
+PXD013897,20170907lc_10007_16653_02F256521.mzid.gz,No MS:1002511 CV param found
+PXD013899,20160108lc_8081_16595_8F229970.mzid.gz,No MS:1002511 CV param found
+PXD014142,GPM00500045195.mzid.gz,No MS:1002511 CV param found
+PXD014359,C_Lee_141014_CRM_dialysis_NCE20_1.mzid,Incorrect Spectra data reference C_Lee_141014_CRM_dialysis_NCE20_1.raw
+PXD014520,B160812_12_Lumos_LK_IN_190_Francis_Rib_Fra_HCD_DT_3.mzid,Incorrect Spectra data reference B160812_12_Lumos_LK_IN_190_Francis_Rib_Fra_HCD_DT_3.raw
+PXD014523,OpenPepXL_BSA_PDH_HCD.mzid,"Error: Element '{http://psidev.info/psi/pi/mzIdentML/1.2}SpectrumIdentification': No match found for key-sequence ['SIL_16674142190973045917'] of keyref '{http://psidev.info/psi/pi/mzIdentML/1.2}FK_SI_SILR'., Line: 3232 | Error: Element '{http://psidev.info/psi/pi/mzIdentML/1.2}SpectrumIdentificatio..."
+PXD014821,16_TG3_3frags_deltaBy4_2linkFDR.mzid.gz,"Validating file 16_TG3_3frags_deltaBy4_2linkFDR.mzid. | Sorry, we're only supporting 1.2.0 and 1.3.0 (the ones that contain crosslinks). Rejected schema file: mzIdentML1.1.0.xsd | File 16_TG3_3frags_deltaBy4_2linkFDR.mzid is schema invalid."
+PXD015037,SQFT35A5_peptides_1_1_0.mzid,No MS:1002511 CV param found
+PXD015981,H_FFPE_8B.mzid.gz,No MS:1002511 CV param found
+PXD015982,20150517_Fisher_Skin_1257_3050_innerarm_CNBr_01F100818.mzid.gz,No MS:1002511 CV param found
+PXD016224,190621_JJanetzko_Kobilka_9905_JJ1.raw_20191106_Byonic.mzid.gz,No MS:1002511 CV param found
+PXD016442,20190124rs_11676_HA10299_1F272359.mzid.gz,No MS:1002511 CV param found
+PXD016446,20180911rs_11287_WB_7F268356.mzid.gz,No MS:1002511 CV param found
+PXD016448,20190819_rs_12428_VPS25_4_H_FTHCDF279704.mzid.gz,No MS:1002511 CV param found
+PXD016487,20180625rs_HA_CHMP7_5F265654.mzid.gz,No MS:1002511 CV param found
+PXD017290,Mudpit_MassSpectrumF001689.mzid.gz,No MS:1002511 CV param found
+PXD017792,XLE1aE2o.mzid.gz,No MS:1002511 CV param found
+PXD017873,20200302_072815_PBS_X02_01.raw.mzid.gz,No MS:1002511 CV param found
+PXD018291,pDSPE-Ecoli-chargestate-3-7.mzid.gz,No MS:1002511 CV param found
+PXD018600,CSL9686A8RW2_C2_115_peptides_1_1_0.mzid.gz,No MS:1002511 CV param found
+PXD018687,SHR72_3_blank.mzid.gz,No MS:1002511 CV param found
+PXD018701,180209_A9.mzid.gz,No MS:1002511 CV param found
+PXD018935,Ribosome_3B.mzid,No MS:1002511 CV param found
+PXD019017,TRY_AMPK_DSSO_XL-MS.mzid,No MS:1002511 CV param found
+PXD019713,mapx_xlink_17.mzid.gz,No MS:1002511 CV param found
+PXD019868,mapeixiang_xlink_CD38_1-100.mzid.gz,No MS:1002511 CV param found
+PXD019944,mapx_xlink_13-4.mzid.gz,No MS:1002511 CV param found
+PXD020418,Arr_both.mzid.gz,No MS:1002511 CV param found
+PXD020666,peptides_lz_1_1_0.mzid.gz,No MS:1002511 CV param found
+PXD020958,Ya116-DTASelect-filter.mzid.gz,No MS:1002511 CV param found
+PXD022163,Mudpit_30_12_1.mzid.gz,No MS:1002511 CV param found
+PXD022279,2020-02-11-yj-backus-jcII16.mzid.gz,No MS:1002511 CV param found
+PXD022440,IP_15min_ctrlF064862.mzid.gz,No MS:1002511 CV param found
+PXD023525,E1oE2oCDI.mzid.gz,No MS:1002511 CV param found
+PXD024065,X-link_trypsin_Craig_Y351Bpa__F002057_.mzid.gz,No MS:1002511 CV param found
+PXD024253,117-pDSBE-BSA2.mzid.gz,No MS:1002511 CV param found
+PXD024373,2018_7_52_30_AM_File_Size__774968583__Byte___F022342_.mzid.gz,No MS:1002511 CV param found
+PXD026101,RWPE1_mTOR_R1881_Torin1_Rep1.mzid.gz,No MS:1002511 CV param found
+PXD026622,Anish_iTRAQ_3h_SPSMS3_fraction1_12.mzid.gz,No MS:1002511 CV param found
+PXD026674,2020-05-30-yj-140min-200nl-Yan-Xue-Steve-Jacobsen-1-WT-1-B.mzid.gz,No MS:1002511 CV param found
+PXD026829,BphP_monomer.mzid.gz,"Error: Element '{http://psidev.info/psi/pi/mzIdentML/1.2}cvParam': The attribute 'accession' is required but missing., Line: 6635 | Error: Element '{http://psidev.info/psi/pi/mzIdentML/1.2}cvParam': The attribute 'name' is required but missing., Line: 6635 | File BphP_monomer.mzid is schema invalid."
+PXD027149,02_V1.mzid.gz,No MS:1002511 CV param found
+PXD027655,F271205.mzid,No MS:1002511 CV param found
+PXD028685,Belogurov_012_20210327_ZR_ES-2.mzid.gz,No MS:1002511 CV param found
+PXD028919,20191114_bbm1840_20-1968_Troyanovsky_03__F025433_.mzid.gz,No MS:1002511 CV param found
+PXD029749,211021L-BY116_518_CF-trypsin_13-iso-2OH.mzid.gz,No MS:1002511 CV param found
+PXD029833,export_Mzidentml_F141165.mzid.gz,No MS:1002511 CV param found
+PXD030048,export_Mzidentml_F002195.mzid.gz,No MS:1002511 CV param found
+PXD031159,20201202_SUMO2_49B3_3SIM_MBP_rep1.mzid.gz,No MS:1002511 CV param found
+PXD031166,051_EL-X-007_F20__F066039_.mzid.gz,No MS:1002511 CV param found
+PXD031261,Mudpit_3_1__3_1.mzid.gz,No MS:1002511 CV param found
+PXD031385,MSB51076A__F172202_.mzid.gz,No MS:1002511 CV param found
+PXD033004,Closed-search-Amanda_DTB-PT_500ug.mzid,No MS:1002511 CV param found
+PXD033175,04122018_Gavis_YP_285_egfp_glo_Xlink.mzid.gz,No MS:1002511 CV param found
+PXD033615,549260_RYBP_Input.mzid.gz,No MS:1002511 CV param found
+PXD035201,20210625_Rix_Yi_Exclusion_FBDD_92_2.raw__F002653_.mzid.gz,No MS:1002511 CV param found
+PXD035655,peptides_1_1_0.mzid.gz,No MS:1002511 CV param found
+PXD037894,PD1279_SuTex_FBDD_siGSTZ1_bio1_run1.raw__F003494_.mzid.gz,No MS:1002511 CV param found
+PXD037983,F1_peptides_1_1_0.mzid.gz,No MS:1002511 CV param found
+PXD038128,190627_VLopez_Khavari_9923_PR1_VLP_PBS_m3.raw_20190702_Byonic.mzid.gz,No MS:1002511 CV param found
+PXD039612,All_Rat-rewiewed.mzid.gz,No MS:1002511 CV param found
+PXD041334,560155_797_Myc_BioTAP2.mzid.gz,No MS:1002511 CV param found
+PXD042282,2022_7_32_54_PM_FileSize_500998639_Byte_F010303.mzid.gz,No MS:1002511 CV param found
+PXD043595,MPA_HA_Frac_peptides_1_1_0.mzid,No MS:1002511 CV param found
+PXD044574,GPM22200017991.mzid.gz,No MS:1002511 CV param found
+PXD044625,20230104_AH_BLQE_HekSIV_IAAUV_IAA4UV_TC20220526_230109.raw_20230121_Byonic_C.mzid.gz,No MS:1002511 CV param found
+PXD046895,R545-Xlink_Craig_F020244.mzid.gz,No MS:1002511 CV param found
+PXD048297,peptides_1_1_0.mzid.gz,No MS:1002511 CV param found
+PXD048298,peptides_1_1_0.mzid.gz,No MS:1002511 CV param found
+PXD051423,E240411_AMC_Mart_LDLandLDLR_SulfoSDA_007and013Ratios_AllData_Xi1.8_filtered_searches_4CCFrags_5TotFrags.mzid.gz,"Error: Element '{http://psidev.info/psi/pi/mzIdentML/1.2}cvParam': The attribute 'cvRef' is required but missing., Line: 10152 | Error: Element '{http://psidev.info/psi/pi/mzIdentML/1.2}cvParam': The attribute 'accession' is required but missing., Line: 10152 | File E240411_AMC_Mart_LDLandLDLR_Sulfo..."
+PXD051588,E240418_AMC_Mart_LDLandLDLR_SulfoSDA_05and1Ratios_pepSEC_A2toB6_AspN_pepSEC_A3toB6_Xi1.8_ManFilt_4CCFrags_5TotFrags.mzid.gz,"Error: Element '{http://psidev.info/psi/pi/mzIdentML/1.2}cvParam': The attribute 'cvRef' is required but missing., Line: 8279 | Error: Element '{http://psidev.info/psi/pi/mzIdentML/1.2}cvParam': The attribute 'accession' is required but missing., Line: 8279 | File E240418_AMC_Mart_LDLandLDLR_SulfoSD..."
+PXD051688,2023-1215_Ecoli-TMT18plex-TotalPeptideAmount.mzid.gz,No MS:1002511 CV param found
+PXD051742,DSSO_QBP_monolinks.mzid.gz,No MS:1002511 CV param found
+PXD051913,2023_6_54_27_PM_FileSize_1168419053_Byte_F012936.mzid.gz,No MS:1002511 CV param found
+PXD052138,JimiKim_infected_NSP2_NAQ444_220121_1.mzid.gz,No MS:1002511 CV param found
+PXD052832,Mito_merged_norm.mzid.gz,Validation timed out
+PXD053253,Experiment_JMS987_S4_MAM_WT_2_from_JMS988_Fusion_S4_MAM_WT_2.mzid.gz,No MS:1002511 CV param found
+PXD053415,Experiment_RA912_7MAM_from_RA912_67MAM.mzid.gz,No MS:1002511 CV param found
+PXD054199,P1129-1.mzid.gz,No MS:1002511 CV param found
+PXD055077,SUMOylation_PhoX_TBDSPP_FAIMS_140823.mzid.gz,File SUMOylation_PhoX_TBDSPP_FAIMS_140823.mzid is schema valid. | Error parsing SUMOylation_PhoX_TBDSPP_FAIMS_140823.mzid | list index out of range
+PXD055169,OrbitrapLUMOS_20230204_06_ITMSms3cid.mzid,No MS:1002511 CV param found
+PXD055405,mascot_daemon_merge__BT444_COLLA1_N1_.mzid.gz,No MS:1002511 CV param found
+PXD055411,mascot_daemon_merge__20190206_collagen_bt474__n2_matrixes_.mzid.gz,No MS:1002511 CV param found
+PXD055603,mascot_daemon_merge__20170603_HM_2DE_RESITANCE_N3_.mzid.gz,No MS:1002511 CV param found
+PXD056510,E240411_AMC_Mart_LDLandLDLR_SulfoSDA_007and013Ratios_AllData_Xi1.8_filtered_searches_4CCFrags_5TotFrags.mzid.gz,"Error: Element '{http://psidev.info/psi/pi/mzIdentML/1.2}cvParam': The attribute 'cvRef' is required but missing., Line: 10152 | Error: Element '{http://psidev.info/psi/pi/mzIdentML/1.2}cvParam': The attribute 'accession' is required but missing., Line: 10152 | File E240411_AMC_Mart_LDLandLDLR_Sulfo..."
+PXD059096,Cas9_DSSO_amountOpti_FAIMS_final_part1.mzid,"Error: Element '{http://psidev.info/psi/pi/mzIdentML/1.2}PeptideEvidence': Duplicate key-sequence ['PE_4258_XL_-2423_4258_672_677_-7144187100368442005'] in unique identity-constraint '{http://psidev.info/psi/pi/mzIdentML/1.2}PK_SCPEPEVLIPEPEV'., Line: 1808011 | Error: Element '{http://psidev.info/ps..."
+PXD059974,WT_DHSO_25mM_Dimer_DDA_2.mzid.gz,No MS:1002511 CV param found
+PXD060469,4A_DHSO_5mM_Mono_DDA_2.mzid,No MS:1002511 CV param found
+PXD061187,2504_02.mzid,No MS:1002511 CV param found
+PXD061667,Separase-Scc1_Fusion_Cohesin_SulfoSDA_inVitroXL_pepSEC_SelectedDiaz_KYST_3mc_Ccm-SDA_3mods_250127_FDR_1-5_Boost_ResiduePairs_between_100contaminants.mzid,"Error: Element '{http://psidev.info/psi/pi/mzIdentML/1.2}cvParam': The attribute 'cvRef' is required but missing., Line: 7503 | Error: Element '{http://psidev.info/psi/pi/mzIdentML/1.2}cvParam': The attribute 'accession' is required but missing., Line: 7503 | File Separase-Scc1_Fusion_Cohesin_SulfoS..."
+PXD065859,E250317_AMC_HSA_C1_IV_Enriched_Uncleaved_pepSEC_A4toB6_ReSearchedWithPeaks_Xi1.8_filt_PSU_OR_5SU.mzid,"Error: Element '{http://psidev.info/psi/pi/mzIdentML/1.2}cvParam': The attribute 'cvRef' is required but missing., Line: 343 | Error: Element '{http://psidev.info/psi/pi/mzIdentML/1.2}cvParam': The attribute 'accession' is required but missing., Line: 343 | File E250317_AMC_HSA_C1_IV_Enriched_Unclea..."
+PXD065869,20250422_HSA_C1_HCD_Dose_BothBioReps_ReSearch_Xi1.8_PSU_ONLY.mzid,"Error: Element '{http://psidev.info/psi/pi/mzIdentML/1.2}cvParam': The attribute 'cvRef' is required but missing., Line: 1857 | Error: Element '{http://psidev.info/psi/pi/mzIdentML/1.2}cvParam': The attribute 'accession' is required but missing., Line: 1857 | File 20250422_HSA_C1_HCD_Dose_BothBioRep..."
+PXD065870,E240906_AMC_HSA_VSD_IV_pepSEC_A5toB6_Xi1.8_ManFilt_3CC_5Tot.mzid,"Error: Element '{http://psidev.info/psi/pi/mzIdentML/1.2}cvParam': The attribute 'cvRef' is required but missing., Line: 315 | Error: Element '{http://psidev.info/psi/pi/mzIdentML/1.2}cvParam': The attribute 'accession' is required but missing., Line: 315 | File E240906_AMC_HSA_VSD_IV_pepSEC_A5toB6_..."
+PXD065871,E250328_AMC_rpn1_IP_VDB_IV_Dose_pepSEC_A3toB6_Filt_3CC_5Tot.mzid,"Error: Element '{http://psidev.info/psi/pi/mzIdentML/1.2}cvParam': The attribute 'cvRef' is required but missing., Line: 2214 | Error: Element '{http://psidev.info/psi/pi/mzIdentML/1.2}cvParam': The attribute 'accession' is required but missing., Line: 2214 | File E250328_AMC_rpn1_IP_VDB_IV_Dose_pep..."
+PXD065946,E250225_AMC_rpn1_IP_SDA_IV_Dose_pepSEC_A3toB6_TwoInj_filt_FixedFasta_3CC_5Tot.mzid,"Error: Element '{http://psidev.info/psi/pi/mzIdentML/1.2}cvParam': The attribute 'cvRef' is required but missing., Line: 4240 | Error: Element '{http://psidev.info/psi/pi/mzIdentML/1.2}cvParam': The attribute 'accession' is required but missing., Line: 4240 | File E250225_AMC_rpn1_IP_SDA_IV_Dose_pep..."
+PXD065956,E241202_AMC_HeLa_C1_IS_Sol_Enriched_pepSEC_Uncleaved_A3toB6_Xi1.8_comb_filt_1CC_3Tot.mzid,"Error: Element '{http://psidev.info/psi/pi/mzIdentML/1.2}cvParam': The attribute 'cvRef' is required but missing., Line: 13818 | Error: Element '{http://psidev.info/psi/pi/mzIdentML/1.2}cvParam': The attribute 'accession' is required but missing., Line: 13818 | File E241202_AMC_HeLa_C1_IS_Sol_Enrich..."
+PXD065958,E240905_AMC_Ecoli_C1_InSitu_Enriched_pepSEC_A5toB6_Xi1.8_3CCFrags.mzid,"Error: Element '{http://psidev.info/psi/pi/mzIdentML/1.2}cvParam': The attribute 'cvRef' is required but missing., Line: 344 | Error: Element '{http://psidev.info/psi/pi/mzIdentML/1.2}cvParam': The attribute 'accession' is required but missing., Line: 344 | File E240905_AMC_Ecoli_C1_InSitu_Enriched_..."
+PXD065961,E250501_AMC_HSA_Only_C1_IV_Enriched_pepSEC_A3toB6_PeaksAnnotated_Xi1.8_filt_PSU_OR_5SU.mzid,Validation timed out


### PR DESCRIPTION
Automated update from crosslinking-maintainer validation pipeline.

New entries:
- PXD001593 (83NWI-US_1apr2010undigestedF059907.mzid.gz): No MS:1002511 CV param found
- PXD001677 (result_DynamicDBReduction.mzid.gz): Validating file result_DynamicDBReduction.mzid. | Sorry, we're only supporting 1.2.0 and 1.3.0 (the ones that contain crosslinks). Rejected schema file: mzIdentML1.1.0.xsd | File result_DynamicDBReduction.mzid is schema invalid.
- PXD003532 (Experimentmaxquantresults_18_4w1fromQEPlus2_12172015_18_4w1.mzid.gz): No MS:1002511 CV param found
- PXD003718 (Baits_ORF4259Nter_ORF4259Cterandwildtype_scaffold_mascot_giardia.mzid.gz): No MS:1002511 CV param found
- PXD004473 (CW2177_mzIdentML.mzid): No MS:1002511 CV param found
- PXD004583 (20131210sr_5587_rev_c_3F192213.mzid.gz): No MS:1002511 CV param found
- PXD004722 (p1.mzid): No MS:1002511 CV param found
- PXD005461 (OBJ7527_F059818.mzid.gz): No MS:1002511 CV param found
- PXD005786 (272218_BICR_ZNF532_NBioTAP_Input.mzid): No MS:1002511 CV param found
- PXD006079 (272099_Barry_CG_Strep.mzid): No MS:1002511 CV param found
- PXD006574 (monomerResults.mzid.gz): Validating file monomerResults.mzid. | Sorry, we're only supporting 1.2.0 and 1.3.0 (the ones that contain crosslinks). Rejected schema file: mzIdentML1.1.0.xsd | File monomerResults.mzid is schema invalid.
- PXD006938 (2_NFS1-Fxn-IscU_MarkleyF016506.mzid.gz): No MS:1002511 CV param found
- PXD007716 (F074077.mzid.gz): No MS:1002511 CV param found
- PXD007836 (peptides_1_1_0.mzid.gz): No MS:1002511 CV param found
- PXD008680 (20140107U2OSCytoD_B_F019267.mzid): No MS:1002511 CV param found
- PXD009239 (FileName_SM-PRI-STD2.rawF031165.mzid.gz): No MS:1002511 CV param found
- PXD009641 (ID16362_01_E749_3008_030315F056135.mzid.gz): No MS:1002511 CV param found
- PXD012225 (Mudpit_20181104_AIssaian_Clot_Frac_xLink_6_HCDFTF101833.mzid.gz): No MS:1002511 CV param found
- PXD012466 (mapeixiang-NSSO-3.mzid.gz): No MS:1002511 CV param found
- PXD012753 (F009919_MouseSkinDermis_Urea_YoungOldOVX.mzid.gz): No MS:1002511 CV param found
- PXD012754 (F010084_MouseSkinDermis_NaCl_YoungOld.mzid.gz): No MS:1002511 CV param found
- PXD012759 (PCR3.mzid): No MS:1002511 CV param found
- PXD013890 (20151203lc_8000_7723_2F228836.mzid.gz): No MS:1002511 CV param found
- PXD013896 (20170823lc_9968_17195_7F255991.mzid.gz): No MS:1002511 CV param found
- PXD013897 (20170907lc_10007_16653_02F256521.mzid.gz): No MS:1002511 CV param found
- PXD013899 (20160108lc_8081_16595_8F229970.mzid.gz): No MS:1002511 CV param found
- PXD014142 (GPM00500045195.mzid.gz): No MS:1002511 CV param found
- PXD014359 (C_Lee_141014_CRM_dialysis_NCE20_1.mzid): Incorrect Spectra data reference C_Lee_141014_CRM_dialysis_NCE20_1.raw
- PXD014520 (B160812_12_Lumos_LK_IN_190_Francis_Rib_Fra_HCD_DT_3.mzid): Incorrect Spectra data reference B160812_12_Lumos_LK_IN_190_Francis_Rib_Fra_HCD_DT_3.raw
- PXD014523 (OpenPepXL_BSA_PDH_HCD.mzid): Error: Element '{http://psidev.info/psi/pi/mzIdentML/1.2}SpectrumIdentification': No match found for key-sequence ['SIL_16674142190973045917'] of keyref '{http://psidev.info/psi/pi/mzIdentML/1.2}FK_SI_SILR'., Line: 3232 | Error: Element '{http://psidev.info/psi/pi/mzIdentML/1.2}SpectrumIdentificatio...
- PXD014821 (16_TG3_3frags_deltaBy4_2linkFDR.mzid.gz): Validating file 16_TG3_3frags_deltaBy4_2linkFDR.mzid. | Sorry, we're only supporting 1.2.0 and 1.3.0 (the ones that contain crosslinks). Rejected schema file: mzIdentML1.1.0.xsd | File 16_TG3_3frags_deltaBy4_2linkFDR.mzid is schema invalid.
- PXD015037 (SQFT35A5_peptides_1_1_0.mzid): No MS:1002511 CV param found
- PXD015981 (H_FFPE_8B.mzid.gz): No MS:1002511 CV param found
- PXD015982 (20150517_Fisher_Skin_1257_3050_innerarm_CNBr_01F100818.mzid.gz): No MS:1002511 CV param found
- PXD016224 (190621_JJanetzko_Kobilka_9905_JJ1.raw_20191106_Byonic.mzid.gz): No MS:1002511 CV param found
- PXD016442 (20190124rs_11676_HA10299_1F272359.mzid.gz): No MS:1002511 CV param found
- PXD016446 (20180911rs_11287_WB_7F268356.mzid.gz): No MS:1002511 CV param found
- PXD016448 (20190819_rs_12428_VPS25_4_H_FTHCDF279704.mzid.gz): No MS:1002511 CV param found
- PXD016487 (20180625rs_HA_CHMP7_5F265654.mzid.gz): No MS:1002511 CV param found
- PXD017290 (Mudpit_MassSpectrumF001689.mzid.gz): No MS:1002511 CV param found
- PXD017792 (XLE1aE2o.mzid.gz): No MS:1002511 CV param found
- PXD017873 (20200302_072815_PBS_X02_01.raw.mzid.gz): No MS:1002511 CV param found
- PXD018291 (pDSPE-Ecoli-chargestate-3-7.mzid.gz): No MS:1002511 CV param found
- PXD018600 (CSL9686A8RW2_C2_115_peptides_1_1_0.mzid.gz): No MS:1002511 CV param found
- PXD018687 (SHR72_3_blank.mzid.gz): No MS:1002511 CV param found
- PXD018701 (180209_A9.mzid.gz): No MS:1002511 CV param found
- PXD018935 (Ribosome_3B.mzid): No MS:1002511 CV param found
- PXD019017 (TRY_AMPK_DSSO_XL-MS.mzid): No MS:1002511 CV param found
- PXD019713 (mapx_xlink_17.mzid.gz): No MS:1002511 CV param found
- PXD019868 (mapeixiang_xlink_CD38_1-100.mzid.gz): No MS:1002511 CV param found
- PXD019944 (mapx_xlink_13-4.mzid.gz): No MS:1002511 CV param found
- PXD020418 (Arr_both.mzid.gz): No MS:1002511 CV param found
- PXD020666 (peptides_lz_1_1_0.mzid.gz): No MS:1002511 CV param found
- PXD020958 (Ya116-DTASelect-filter.mzid.gz): No MS:1002511 CV param found
- PXD022163 (Mudpit_30_12_1.mzid.gz): No MS:1002511 CV param found
- PXD022279 (2020-02-11-yj-backus-jcII16.mzid.gz): No MS:1002511 CV param found
- PXD022440 (IP_15min_ctrlF064862.mzid.gz): No MS:1002511 CV param found
- PXD023525 (E1oE2oCDI.mzid.gz): No MS:1002511 CV param found
- PXD024065 (X-link_trypsin_Craig_Y351Bpa__F002057_.mzid.gz): No MS:1002511 CV param found
- PXD024253 (117-pDSBE-BSA2.mzid.gz): No MS:1002511 CV param found
- PXD024373 (2018_7_52_30_AM_File_Size__774968583__Byte___F022342_.mzid.gz): No MS:1002511 CV param found
- PXD026101 (RWPE1_mTOR_R1881_Torin1_Rep1.mzid.gz): No MS:1002511 CV param found
- PXD026622 (Anish_iTRAQ_3h_SPSMS3_fraction1_12.mzid.gz): No MS:1002511 CV param found
- PXD026674 (2020-05-30-yj-140min-200nl-Yan-Xue-Steve-Jacobsen-1-WT-1-B.mzid.gz): No MS:1002511 CV param found
- PXD026829 (BphP_monomer.mzid.gz): Error: Element '{http://psidev.info/psi/pi/mzIdentML/1.2}cvParam': The attribute 'accession' is required but missing., Line: 6635 | Error: Element '{http://psidev.info/psi/pi/mzIdentML/1.2}cvParam': The attribute 'name' is required but missing., Line: 6635 | File BphP_monomer.mzid is schema invalid.
- PXD027149 (02_V1.mzid.gz): No MS:1002511 CV param found
- PXD027655 (F271205.mzid): No MS:1002511 CV param found
- PXD028685 (Belogurov_012_20210327_ZR_ES-2.mzid.gz): No MS:1002511 CV param found
- PXD028919 (20191114_bbm1840_20-1968_Troyanovsky_03__F025433_.mzid.gz): No MS:1002511 CV param found
- PXD029749 (211021L-BY116_518_CF-trypsin_13-iso-2OH.mzid.gz): No MS:1002511 CV param found
- PXD029833 (export_Mzidentml_F141165.mzid.gz): No MS:1002511 CV param found
- PXD030048 (export_Mzidentml_F002195.mzid.gz): No MS:1002511 CV param found
- PXD031159 (20201202_SUMO2_49B3_3SIM_MBP_rep1.mzid.gz): No MS:1002511 CV param found
- PXD031166 (051_EL-X-007_F20__F066039_.mzid.gz): No MS:1002511 CV param found
- PXD031261 (Mudpit_3_1__3_1.mzid.gz): No MS:1002511 CV param found
- PXD031385 (MSB51076A__F172202_.mzid.gz): No MS:1002511 CV param found
- PXD033004 (Closed-search-Amanda_DTB-PT_500ug.mzid): No MS:1002511 CV param found
- PXD033175 (04122018_Gavis_YP_285_egfp_glo_Xlink.mzid.gz): No MS:1002511 CV param found
- PXD033615 (549260_RYBP_Input.mzid.gz): No MS:1002511 CV param found
- PXD035201 (20210625_Rix_Yi_Exclusion_FBDD_92_2.raw__F002653_.mzid.gz): No MS:1002511 CV param found
- PXD035655 (peptides_1_1_0.mzid.gz): No MS:1002511 CV param found
- PXD037894 (PD1279_SuTex_FBDD_siGSTZ1_bio1_run1.raw__F003494_.mzid.gz): No MS:1002511 CV param found
- PXD037983 (F1_peptides_1_1_0.mzid.gz): No MS:1002511 CV param found
- PXD038128 (190627_VLopez_Khavari_9923_PR1_VLP_PBS_m3.raw_20190702_Byonic.mzid.gz): No MS:1002511 CV param found
- PXD039612 (All_Rat-rewiewed.mzid.gz): No MS:1002511 CV param found
- PXD041334 (560155_797_Myc_BioTAP2.mzid.gz): No MS:1002511 CV param found
- PXD042282 (2022_7_32_54_PM_FileSize_500998639_Byte_F010303.mzid.gz): No MS:1002511 CV param found
- PXD043595 (MPA_HA_Frac_peptides_1_1_0.mzid): No MS:1002511 CV param found
- PXD044574 (GPM22200017991.mzid.gz): No MS:1002511 CV param found
- PXD044625 (20230104_AH_BLQE_HekSIV_IAAUV_IAA4UV_TC20220526_230109.raw_20230121_Byonic_C.mzid.gz): No MS:1002511 CV param found
- PXD046895 (R545-Xlink_Craig_F020244.mzid.gz): No MS:1002511 CV param found
- PXD048297 (peptides_1_1_0.mzid.gz): No MS:1002511 CV param found
- PXD048298 (peptides_1_1_0.mzid.gz): No MS:1002511 CV param found
- PXD051423 (E240411_AMC_Mart_LDLandLDLR_SulfoSDA_007and013Ratios_AllData_Xi1.8_filtered_searches_4CCFrags_5TotFrags.mzid.gz): Error: Element '{http://psidev.info/psi/pi/mzIdentML/1.2}cvParam': The attribute 'cvRef' is required but missing., Line: 10152 | Error: Element '{http://psidev.info/psi/pi/mzIdentML/1.2}cvParam': The attribute 'accession' is required but missing., Line: 10152 | File E240411_AMC_Mart_LDLandLDLR_Sulfo...
- PXD051588 (E240418_AMC_Mart_LDLandLDLR_SulfoSDA_05and1Ratios_pepSEC_A2toB6_AspN_pepSEC_A3toB6_Xi1.8_ManFilt_4CCFrags_5TotFrags.mzid.gz): Error: Element '{http://psidev.info/psi/pi/mzIdentML/1.2}cvParam': The attribute 'cvRef' is required but missing., Line: 8279 | Error: Element '{http://psidev.info/psi/pi/mzIdentML/1.2}cvParam': The attribute 'accession' is required but missing., Line: 8279 | File E240418_AMC_Mart_LDLandLDLR_SulfoSD...
- PXD051688 (2023-1215_Ecoli-TMT18plex-TotalPeptideAmount.mzid.gz): No MS:1002511 CV param found
- PXD051742 (DSSO_QBP_monolinks.mzid.gz): No MS:1002511 CV param found
- PXD051913 (2023_6_54_27_PM_FileSize_1168419053_Byte_F012936.mzid.gz): No MS:1002511 CV param found
- PXD052138 (JimiKim_infected_NSP2_NAQ444_220121_1.mzid.gz): No MS:1002511 CV param found
- PXD052832 (Mito_merged_norm.mzid.gz): Validation timed out
- PXD053253 (Experiment_JMS987_S4_MAM_WT_2_from_JMS988_Fusion_S4_MAM_WT_2.mzid.gz): No MS:1002511 CV param found
- PXD053415 (Experiment_RA912_7MAM_from_RA912_67MAM.mzid.gz): No MS:1002511 CV param found
- PXD054199 (P1129-1.mzid.gz): No MS:1002511 CV param found
- PXD055077 (SUMOylation_PhoX_TBDSPP_FAIMS_140823.mzid.gz): File SUMOylation_PhoX_TBDSPP_FAIMS_140823.mzid is schema valid. | Error parsing SUMOylation_PhoX_TBDSPP_FAIMS_140823.mzid | list index out of range
- PXD055169 (OrbitrapLUMOS_20230204_06_ITMSms3cid.mzid): No MS:1002511 CV param found
- PXD055405 (mascot_daemon_merge__BT444_COLLA1_N1_.mzid.gz): No MS:1002511 CV param found
- PXD055411 (mascot_daemon_merge__20190206_collagen_bt474__n2_matrixes_.mzid.gz): No MS:1002511 CV param found
- PXD055603 (mascot_daemon_merge__20170603_HM_2DE_RESITANCE_N3_.mzid.gz): No MS:1002511 CV param found
- PXD056510 (E240411_AMC_Mart_LDLandLDLR_SulfoSDA_007and013Ratios_AllData_Xi1.8_filtered_searches_4CCFrags_5TotFrags.mzid.gz): Error: Element '{http://psidev.info/psi/pi/mzIdentML/1.2}cvParam': The attribute 'cvRef' is required but missing., Line: 10152 | Error: Element '{http://psidev.info/psi/pi/mzIdentML/1.2}cvParam': The attribute 'accession' is required but missing., Line: 10152 | File E240411_AMC_Mart_LDLandLDLR_Sulfo...
- PXD059096 (Cas9_DSSO_amountOpti_FAIMS_final_part1.mzid): Error: Element '{http://psidev.info/psi/pi/mzIdentML/1.2}PeptideEvidence': Duplicate key-sequence ['PE_4258_XL_-2423_4258_672_677_-7144187100368442005'] in unique identity-constraint '{http://psidev.info/psi/pi/mzIdentML/1.2}PK_SCPEPEVLIPEPEV'., Line: 1808011 | Error: Element '{http://psidev.info/ps...
- PXD059974 (WT_DHSO_25mM_Dimer_DDA_2.mzid.gz): No MS:1002511 CV param found
- PXD060469 (4A_DHSO_5mM_Mono_DDA_2.mzid): No MS:1002511 CV param found
- PXD061187 (2504_02.mzid): No MS:1002511 CV param found
- PXD061667 (Separase-Scc1_Fusion_Cohesin_SulfoSDA_inVitroXL_pepSEC_SelectedDiaz_KYST_3mc_Ccm-SDA_3mods_250127_FDR_1-5_Boost_ResiduePairs_between_100contaminants.mzid): Error: Element '{http://psidev.info/psi/pi/mzIdentML/1.2}cvParam': The attribute 'cvRef' is required but missing., Line: 7503 | Error: Element '{http://psidev.info/psi/pi/mzIdentML/1.2}cvParam': The attribute 'accession' is required but missing., Line: 7503 | File Separase-Scc1_Fusion_Cohesin_SulfoS...
- PXD065859 (E250317_AMC_HSA_C1_IV_Enriched_Uncleaved_pepSEC_A4toB6_ReSearchedWithPeaks_Xi1.8_filt_PSU_OR_5SU.mzid): Error: Element '{http://psidev.info/psi/pi/mzIdentML/1.2}cvParam': The attribute 'cvRef' is required but missing., Line: 343 | Error: Element '{http://psidev.info/psi/pi/mzIdentML/1.2}cvParam': The attribute 'accession' is required but missing., Line: 343 | File E250317_AMC_HSA_C1_IV_Enriched_Unclea...
- PXD065869 (20250422_HSA_C1_HCD_Dose_BothBioReps_ReSearch_Xi1.8_PSU_ONLY.mzid): Error: Element '{http://psidev.info/psi/pi/mzIdentML/1.2}cvParam': The attribute 'cvRef' is required but missing., Line: 1857 | Error: Element '{http://psidev.info/psi/pi/mzIdentML/1.2}cvParam': The attribute 'accession' is required but missing., Line: 1857 | File 20250422_HSA_C1_HCD_Dose_BothBioRep...
- PXD065870 (E240906_AMC_HSA_VSD_IV_pepSEC_A5toB6_Xi1.8_ManFilt_3CC_5Tot.mzid): Error: Element '{http://psidev.info/psi/pi/mzIdentML/1.2}cvParam': The attribute 'cvRef' is required but missing., Line: 315 | Error: Element '{http://psidev.info/psi/pi/mzIdentML/1.2}cvParam': The attribute 'accession' is required but missing., Line: 315 | File E240906_AMC_HSA_VSD_IV_pepSEC_A5toB6_...
- PXD065871 (E250328_AMC_rpn1_IP_VDB_IV_Dose_pepSEC_A3toB6_Filt_3CC_5Tot.mzid): Error: Element '{http://psidev.info/psi/pi/mzIdentML/1.2}cvParam': The attribute 'cvRef' is required but missing., Line: 2214 | Error: Element '{http://psidev.info/psi/pi/mzIdentML/1.2}cvParam': The attribute 'accession' is required but missing., Line: 2214 | File E250328_AMC_rpn1_IP_VDB_IV_Dose_pep...
- PXD065946 (E250225_AMC_rpn1_IP_SDA_IV_Dose_pepSEC_A3toB6_TwoInj_filt_FixedFasta_3CC_5Tot.mzid): Error: Element '{http://psidev.info/psi/pi/mzIdentML/1.2}cvParam': The attribute 'cvRef' is required but missing., Line: 4240 | Error: Element '{http://psidev.info/psi/pi/mzIdentML/1.2}cvParam': The attribute 'accession' is required but missing., Line: 4240 | File E250225_AMC_rpn1_IP_SDA_IV_Dose_pep...
- PXD065956 (E241202_AMC_HeLa_C1_IS_Sol_Enriched_pepSEC_Uncleaved_A3toB6_Xi1.8_comb_filt_1CC_3Tot.mzid): Error: Element '{http://psidev.info/psi/pi/mzIdentML/1.2}cvParam': The attribute 'cvRef' is required but missing., Line: 13818 | Error: Element '{http://psidev.info/psi/pi/mzIdentML/1.2}cvParam': The attribute 'accession' is required but missing., Line: 13818 | File E241202_AMC_HeLa_C1_IS_Sol_Enrich...
- PXD065958 (E240905_AMC_Ecoli_C1_InSitu_Enriched_pepSEC_A5toB6_Xi1.8_3CCFrags.mzid): Error: Element '{http://psidev.info/psi/pi/mzIdentML/1.2}cvParam': The attribute 'cvRef' is required but missing., Line: 344 | Error: Element '{http://psidev.info/psi/pi/mzIdentML/1.2}cvParam': The attribute 'accession' is required but missing., Line: 344 | File E240905_AMC_Ecoli_C1_InSitu_Enriched_...
- PXD065961 (E250501_AMC_HSA_Only_C1_IV_Enriched_pepSEC_A3toB6_PeaksAnnotated_Xi1.8_filt_PSU_OR_5SU.mzid): Validation timed out